### PR TITLE
chore: cargo binstall in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
         },
         "ghcr.io/lee-orr/rusty-dev-containers/cargo-binstall:0": {
             "packages": "trunk,leptosfmt,wasm-pack,wasm-opt"
-	},
+        },
         "ghcr.io/nlordell/features/foundry": {}
     },
     "postCreateCommand": "sudo DEBIAN_FRONTEND=noninteractive apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config libssl-dev clang",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,9 +5,12 @@
         "ghcr.io/devcontainers/features/rust:1": {
             "version": "latest"
         },
+	"ghcr.io/lee-orr/rusty-dev-containers/cargo-binstall:0": {
+	    "packages": "trunk,leptosfmt,wasm-pack,wasm-opt"
+	},
         "ghcr.io/nlordell/features/foundry": {}
     },
-    "postCreateCommand": "sudo DEBIAN_FRONTEND=noninteractive apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config libssl-dev clang && cargo install trunk leptosfmt wasm-pack wasm-opt",
+    "postCreateCommand": "sudo DEBIAN_FRONTEND=noninteractive apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config libssl-dev clang",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,8 +5,8 @@
         "ghcr.io/devcontainers/features/rust:1": {
             "version": "latest"
         },
-	"ghcr.io/lee-orr/rusty-dev-containers/cargo-binstall:0": {
-	    "packages": "trunk,leptosfmt,wasm-pack,wasm-opt"
+        "ghcr.io/lee-orr/rusty-dev-containers/cargo-binstall:0": {
+            "packages": "trunk,leptosfmt,wasm-pack,wasm-opt"
 	},
         "ghcr.io/nlordell/features/foundry": {}
     },


### PR DESCRIPTION
This PR:

1. Makes use of cargo binstall within a containerised environment to avoid long compilation times in postCreateCommand.