### PR TITLE
chore: default zsh and install neovim

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,15 +2,20 @@
     "name": "Foundry + Rust Development Container",
     "image": "mcr.microsoft.com/devcontainers/rust:latest",
     "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "configureZshAsDefaultShell": true,
+            "installOhMyZsh": false
+        },
         "ghcr.io/devcontainers/features/rust:1": {
             "version": "latest"
         },
+        "ghcr.io/devcontainers-extra/features/neovim-apt-get:1": {},
         "ghcr.io/lee-orr/rusty-dev-containers/cargo-binstall:0": {
-            "packages": "trunk,leptosfmt,wasm-pack,wasm-opt"
+            "packages": "just,trunk,leptosfmt,wasm-pack,wasm-opt"
         },
         "ghcr.io/nlordell/features/foundry": {}
     },
-    "postCreateCommand": "sudo DEBIAN_FRONTEND=noninteractive apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config libssl-dev clang",
+    "postCreateCommand": "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config libssl-dev clang",
     "customizations": {
         "vscode": {
             "extensions": [


### PR DESCRIPTION
This PR:

1. Sets ZSH as the default shell, however opts not to install oh-my-zsh.
2. Adds neovim and just binaries.