### PR TITLE
chore: nightly rust in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,9 @@
             "installOhMyZsh": false
         },
         "ghcr.io/devcontainers/features/rust:1": {
-            "version": "latest"
+            "version": "nightly-2024-11-29",
+            "profile": "complete",
+            "targets": "wasm32-unknown-unknown"
         },
         "ghcr.io/devcontainers-extra/features/neovim-apt-get:1": {},
         "ghcr.io/lee-orr/rusty-dev-containers/cargo-binstall:0": {
@@ -15,7 +17,7 @@
         },
         "ghcr.io/nlordell/features/foundry": {}
     },
-    "postCreateCommand": "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config libssl-dev clang",
+    "postCreateCommand": "sudo DEBIAN_FRONTEND=noninteractive apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config libssl-dev clang",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
-rust-version = "1.84"
+rust-version = "1.83"
 license = "AGPL-3.0"
 homepage = "https://nullis.xyz/nexum"
 repository = "https://github.com/nullisxyz/nexum"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,0 @@
-[toolchain]
-channel = "nightly"  # Or "nightly" if you require nightly features
-components = ["rustfmt", "clippy"]  # Optional, add components as needed
-targets = ["wasm32-unknown-unknown", "x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]


### PR DESCRIPTION
This PR:

1. Configures nightly rust within the devcontainer by default
2. Adds nvim and just binaries
3. Automatically configures ZSH