### PR TITLE
chore: change base and use feature for pkgs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Foundry + Rust Development Container",
-    "image": "mcr.microsoft.com/devcontainers/rust:latest",
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
     "features": {
         "ghcr.io/devcontainers/features/common-utils:2": {
             "configureZshAsDefaultShell": true,
@@ -11,13 +11,16 @@
             "profile": "complete",
             "targets": "wasm32-unknown-unknown"
         },
-        "ghcr.io/devcontainers-extra/features/neovim-apt-get:1": {},
+        "ghcr.io/devcontainers-extra/features/apt-get-packages:1": {
+            "packages": "pkg-config,libssl-dev,clang"
+        },
         "ghcr.io/lee-orr/rusty-dev-containers/cargo-binstall:0": {
             "packages": "just,trunk,leptosfmt,wasm-pack,wasm-opt"
         },
+        "ghcr.io/duduribeiro/devcontainer-features/neovim:1": {},
+        "ghcr.io/duduribeiro/devcontainer-features/tmux:1": {},
         "ghcr.io/nlordell/features/foundry": {}
     },
-    "postCreateCommand": "sudo DEBIAN_FRONTEND=noninteractive apt-get update && sudo DEBIAN_FRONTEND=noninteractive apt-get install -y pkg-config libssl-dev clang",
     "customizations": {
         "vscode": {
             "extensions": [


### PR DESCRIPTION
This PR:

1. Sets the base image now to the latest ubuntu (this was causing rust to have already been installed, and subsequent feature configurations weren't being applied).
2. Does away with the post create command and enforces additional packages are installed by feature.
3. Builds `nvim` and `tmux` binaries from source.