### PR TITLE
chore(devcontainer): add rust-analyzer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,6 +19,7 @@
         },
         "ghcr.io/duduribeiro/devcontainer-features/neovim:1": {},
         "ghcr.io/duduribeiro/devcontainer-features/tmux:1": {},
+        "ghcr.io/devcontainers/features/node:1": {},
         "ghcr.io/nlordell/features/foundry": {}
     },
     "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -29,6 +29,7 @@
             ]
         }
     },
+    "postCreateCommand": "/usr/local/cargo/bin/rustup component add rust-analyzer",
     "runArgs": [
         "--network=host"
     ]


### PR DESCRIPTION
This PR ensures that:

1. `rust-analyzer` is included for the LSP in neovim
2. node / npm is available for the HTML / CSS LSP in neovim
