### PR TITLE
feat: make `rpc` multichain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1400,33 +1400,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "186dce98367766de751c42c4f03970fc60fc012296e706ccbb9d5df9b6c1e271"
 
 [[package]]
-name = "color-eyre"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
-dependencies = [
- "backtrace",
- "color-spantrace",
- "eyre",
- "indenter",
- "once_cell",
- "owo-colors",
- "tracing-error",
-]
-
-[[package]]
-name = "color-spantrace"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
-dependencies = [
- "once_cell",
- "owo-colors",
- "tracing-core",
- "tracing-error",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3819,12 +3792,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "owo-colors"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
-
-[[package]]
 name = "pad-adapter"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4559,19 +4526,16 @@ dependencies = [
  "alloy",
  "alloy-chains 0.1.47",
  "clap",
- "color-eyre",
  "eyre",
  "futures",
  "hyper",
  "jsonrpsee",
- "lazy_static",
  "paste",
  "serde",
  "serde_json",
  "tokio",
  "tower 0.5.1",
  "tracing",
- "tracing-error",
  "tracing-subscriber",
  "url",
 ]
@@ -5905,16 +5869,6 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-error"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
-dependencies = [
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "alloy-genesis",
  "alloy-network",
  "alloy-provider",
+ "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types",
  "alloy-serde",
@@ -63,6 +64,7 @@ dependencies = [
  "alloy-signer-local",
  "alloy-transport",
  "alloy-transport-http",
+ "alloy-transport-ws",
 ]
 
 [[package]]
@@ -139,6 +141,7 @@ dependencies = [
  "alloy-network-primitives",
  "alloy-primitives 1.1.0",
  "alloy-provider",
+ "alloy-pubsub",
  "alloy-rpc-types-eth",
  "alloy-sol-types",
  "alloy-transport",
@@ -235,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.3"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc71c06880f44758e8c748db17f3e4661240bfa06f665089097e8cdd0583ca4"
+checksum = "1cf47e07c0dbcb8f1fa2c903d9eb32b14fec3dc04e60e7fee29fc0d3799fba34"
 dependencies = [
  "alloy-eips",
  "alloy-primitives 1.1.0",
@@ -379,12 +382,14 @@ dependencies = [
  "alloy-network",
  "alloy-network-primitives",
  "alloy-primitives 1.1.0",
+ "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
  "alloy-signer",
  "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
+ "alloy-transport-ws",
  "async-stream",
  "async-trait",
  "auto_impl",
@@ -402,6 +407,27 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-pubsub"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbeb2dd970e7d70d2d408bc6fba391ad66406d766312399a42d6f93a9586f818"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-primitives 1.1.0",
+ "alloy-transport",
+ "bimap",
+ "futures",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.1",
+ "tracing",
  "wasmtimer",
 ]
 
@@ -435,8 +461,10 @@ checksum = "6707200ade3dd821585ec208022a273889f328ee1e76014c9a81820ef6d3c48d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives 1.1.0",
+ "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
+ "alloy-transport-ws",
  "async-stream",
  "futures",
  "pin-project",
@@ -454,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.3"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a891e871830c1ef6e105a08f615fbb178b2edc4c75c203bf47c64dfa21acd849"
+checksum = "933d9ad7e50156f1cd5574227e6f15c6d237d50006b1754e3f3564d6e8293ed5"
 dependencies = [
  "alloy-primitives 1.1.0",
  "alloy-rpc-types-eth",
@@ -648,6 +676,24 @@ dependencies = [
  "tower 0.5.1",
  "tracing",
  "url",
+]
+
+[[package]]
+name = "alloy-transport-ws"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d39c87d5b9f3dd8e8efdc95bd3aaeef947e7938dbf45cffda9bd5689cd9517"
+dependencies = [
+ "alloy-pubsub",
+ "alloy-transport",
+ "futures",
+ "http",
+ "rustls",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "ws_stream_wasm",
 ]
 
 [[package]]
@@ -923,6 +969,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures",
+ "pharos",
+ "rustc_version 0.4.1",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1016,6 +1073,12 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bimap"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bit-set"
@@ -1157,9 +1220,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]
@@ -1655,6 +1718,12 @@ dependencies = [
  "once_cell",
  "parking_lot_core",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "deltae"
@@ -3883,6 +3952,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pharos"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
+dependencies = [
+ "futures",
+ "rustc_version 0.4.1",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4477,6 +4556,8 @@ checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 name = "rpc"
 version = "0.1.0"
 dependencies = [
+ "alloy",
+ "alloy-chains 0.1.47",
  "clap",
  "color-eyre",
  "eyre",
@@ -4484,6 +4565,7 @@ dependencies = [
  "hyper",
  "jsonrpsee",
  "lazy_static",
+ "paste",
  "serde",
  "serde_json",
  "tokio",
@@ -4491,6 +4573,7 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
@@ -5674,6 +5757,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki-roots",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5888,6 +5987,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.1",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.12",
+ "utf-8",
+]
+
+[[package]]
 name = "typed-builder"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6004,6 +6122,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf16_iter"
@@ -6600,6 +6724,25 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "ws_stream_wasm"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7999f5f4217fe3818726b66257a4475f71e74ffd190776ad053fa159e50737f5"
+dependencies = [
+ "async_io_stream",
+ "futures",
+ "js-sys",
+ "log",
+ "pharos",
+ "rustc_version 0.4.1",
+ "send_wrapper 0.6.0",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ eyre = "0.6.12"
 console_error_panic_hook = "0.1.7"
 
 alloy-chains = { version = "0.1.47", features = ["serde"] }
+alloy = { version = "1.0.3", features = ["signer-keystore", "provider-ws"] }
 
 chrome-sys = { path = "crates/extension/chrome-sys" }
 worker = { path = "crates/extension/worker" }

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -23,3 +23,7 @@ tracing.workspace = true
 tracing-error.workspace = true
 tracing-subscriber.workspace = true
 eyre.workspace = true
+url.workspace = true
+alloy-chains.workspace = true
+alloy.workspace = true
+paste = "1.0.15"

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -10,17 +10,14 @@ exclude.workspace = true
 
 [dependencies]
 clap = { version = "4.5.21", features = ["derive", "cargo", "wrap_help", "unicode", "string", "unstable-styles"] }
-color-eyre = "0.6.3"
 futures.workspace = true
 tower = { version = "0.5", features = ["full"] }
 hyper = "1.3"
-lazy_static = "1.5.0"
 serde.workspace = true
 serde_json.workspace = true
 jsonrpsee = { version = "0.24.7", default-features = false, features = ["server", "http-client", "ws-client", "macros", "client-ws-transport-tls"] }
 tokio = { version = "1.41.1", features = ["full"] }
 tracing.workspace = true
-tracing-error.workspace = true
 tracing-subscriber.workspace = true
 eyre.workspace = true
 url.workspace = true

--- a/crates/rpc/src/bin/rpc.rs
+++ b/crates/rpc/src/bin/rpc.rs
@@ -1,27 +1,46 @@
+use std::net::Ipv4Addr;
+
+use alloy_chains::NamedChain;
 use clap::Parser;
+use eyre::OptionExt;
+use rpc::rpc::{chain_id_or_name_to_named_chain, RpcServerBuilder};
+use url::Url;
 
 #[derive(Parser, Debug)]
 #[command(about)]
 pub struct Args {
-    /// Address to listen for browser extension WebSocket requests
-    #[arg(short, long, value_name = "ADDR", default_value = "127.0.0.1:1248")]
-    pub listen_addr: String,
+    #[arg(short, long, default_value = "127.0.0.1")]
+    pub host: Ipv4Addr,
 
-    /// Node JSON-RPC URL capable of supporting WebSockets
-    #[arg(
-        short,
-        long,
-        value_name = "RPC_URL",
-        default_value = "wss://eth.drpc.org"
-    )]
-    pub rpc_url: String,
+    #[arg(short, long, default_value = "1248")]
+    pub port: u16,
+
+    /// Node JSON-RPC URLs in the format `<chain>=<url>`
+    #[arg(short, long)]
+    pub rpc_urls: Vec<String>,
 }
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
     let args = Args::parse();
     tracing_subscriber::fmt::init();
-    let (handle, _) = rpc::run_server(args.listen_addr.parse()?, args.rpc_url.as_str()).await?;
+
+    let mut builder = RpcServerBuilder::new().host(args.host).port(args.port);
+
+    for (chain, url) in args
+        .rpc_urls
+        .iter()
+        .map(|s: &String| -> eyre::Result<(NamedChain, Url)> {
+            let (chain, rpc) = s.split_once("=").ok_or_eyre("invalid format for rpc url")?;
+            let chain = chain_id_or_name_to_named_chain(chain)?;
+            Ok((chain, rpc.parse()?))
+        })
+        .filter_map(Result::ok)
+    {
+        builder = builder.chain(chain, url);
+    }
+    let mut rpc = builder.build().await;
+    let (handle, _) = rpc.run().await?;
     handle.stopped().await;
 
     Ok(())

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1,4 +1,2 @@
 pub mod namespaces;
 pub mod rpc;
-
-pub use rpc::run_server;

--- a/crates/rpc/src/namespaces/mod.rs
+++ b/crates/rpc/src/namespaces/mod.rs
@@ -2,3 +2,56 @@ pub mod eth;
 pub mod net;
 pub mod wallet;
 pub mod web3;
+
+#[macro_export]
+macro_rules! upstream_request {
+    ($method_name:literal) => {
+        paste::paste! {
+        #[allow(non_snake_case)]
+        async fn [<upstream_ $method_name>]<P> (
+            params: jsonrpsee::types::Params<'static>,
+            context: Arc<$crate::rpc::GlobalRpcContext<P>>,
+            _: jsonrpsee::Extensions,
+        ) -> jsonrpsee::core::RpcResult<serde_json::Value>
+        where
+            P: alloy::providers::Provider,
+        {
+            let params: Result<$crate::rpc::RequestParams, _> = params.parse();
+            tracing::trace!("Received request extension");
+            tracing::trace!(
+                "Received request: {} with params: {:?}",
+                $method_name,
+                params
+            );
+
+            let params: $crate::rpc::RequestParams = match params {
+                Ok(params) => params,
+                Err(_) => return Err(jsonrpsee::types::ErrorObject::from(jsonrpsee::types::ErrorCode::ParseError)),
+            };
+
+            // Perform the request
+            let response: Result<serde_json::Value, alloy::transports::RpcError<alloy::transports::TransportErrorKind>> = context.provider
+                .raw_request(std::borrow::Cow::Borrowed($method_name), params)
+                .await;
+
+            // Match the result and convert errors
+            match response {
+                Ok(res) => Ok(res),
+                Err(_) => Err(jsonrpsee::types::ErrorObject::from(jsonrpsee::types::ErrorCode::InternalError)),
+            }
+        }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! upstream_requests {
+    ($rpc_module:ident, $($method_name:literal),+) => {
+        $(
+            $crate::upstream_request!($method_name);
+            paste::paste! {
+            $rpc_module.register_async_method($method_name, [<upstream_ $method_name>])?;
+            }
+        )+
+    };
+}

--- a/crates/rpc/src/namespaces/net.rs
+++ b/crates/rpc/src/namespaces/net.rs
@@ -1,16 +1,14 @@
-use jsonrpsee::{ws_client::WsClient, RpcModule};
+use alloy::providers::Provider;
+use jsonrpsee::RpcModule;
 use std::sync::Arc;
 
-use crate::rpc::upstream_request;
+use crate::{rpc::GlobalRpcContext, upstream_requests};
 
-pub type NetContext = ();
-
-pub fn init(_: NetContext, client: Arc<WsClient>) -> RpcModule<NetContext> {
-    let mut net_module = RpcModule::new(());
-    let net_methods = vec!["net_version"];
-    net_methods.iter().for_each(|method| {
-        let _ = net_module.register_async_method(method, upstream_request(method, client.clone()));
-    });
-
-    net_module
+pub fn init<P>(context: GlobalRpcContext<P>) -> eyre::Result<RpcModule<GlobalRpcContext<P>>>
+where
+    P: Provider + 'static,
+{
+    let mut net_module = RpcModule::new(context);
+    upstream_requests!(net_module, "net_version");
+    Ok(net_module)
 }

--- a/crates/rpc/src/namespaces/wallet.rs
+++ b/crates/rpc/src/namespaces/wallet.rs
@@ -1,17 +1,12 @@
-use jsonrpsee::{ws_client::WsClient, RpcModule};
-use std::sync::Arc;
+use alloy::providers::Provider;
+use jsonrpsee::RpcModule;
 
-use crate::rpc::upstream_request;
+use crate::rpc::GlobalRpcContext;
 
-pub type WalletContext = ();
-
-pub fn init(_: WalletContext, client: Arc<WsClient>) -> RpcModule<WalletContext> {
-    let mut wallet_module = RpcModule::new(());
-    let wallet_methods: Vec<&str> = vec![];
-    wallet_methods.iter().for_each(|method| {
-        let _ =
-            wallet_module.register_async_method(method, upstream_request(method, client.clone()));
-    });
-
-    wallet_module
+pub fn init<P>(context: GlobalRpcContext<P>) -> eyre::Result<RpcModule<GlobalRpcContext<P>>>
+where
+    P: Provider + 'static,
+{
+    let wallet_module = RpcModule::new(context);
+    Ok(wallet_module)
 }

--- a/crates/rpc/src/namespaces/web3.rs
+++ b/crates/rpc/src/namespaces/web3.rs
@@ -1,17 +1,14 @@
-use jsonrpsee::{ws_client::WsClient, RpcModule};
+use alloy::providers::Provider;
+use jsonrpsee::RpcModule;
 use std::sync::Arc;
 
-use crate::rpc::upstream_request;
+use crate::{rpc::GlobalRpcContext, upstream_requests};
 
-pub type Web3Context = ();
-
-pub fn init(c: Web3Context, client: Arc<WsClient>) -> RpcModule<Web3Context> {
+pub fn init<P>(c: GlobalRpcContext<P>) -> eyre::Result<RpcModule<GlobalRpcContext<P>>>
+where
+    P: Provider + 'static,
+{
     let mut web3_module = RpcModule::new(c);
-
-    let web3_methods = vec!["web3_clientVersion"];
-    web3_methods.iter().for_each(|method| {
-        let _ = web3_module.register_async_method(method, upstream_request(method, client.clone()));
-    });
-
-    web3_module
+    upstream_requests!(web3_module, "web3_clientVersion");
+    Ok(web3_module)
 }

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -15,7 +15,7 @@ ratatui = { version = "0.30.0-alpha.3", features = ["unstable-widget-ref"] }
 tokio.workspace = true
 crossterm = { version = "0.29.0", features = ["event-stream"] }
 futures.workspace = true
-alloy = { version = "1.0.3", features = ["signer-keystore"] }
+alloy.workspace = true
 clap.workspace = true
 rpc.workspace = true
 eyre.workspace = true

--- a/justfile
+++ b/justfile
@@ -13,3 +13,6 @@ build-ext:
 alias re := run-ext
 run-ext:
 	web-ext run -s crates/extension/dist
+
+check:
+	cargo check --all-targets --all-features


### PR DESCRIPTION
- Use alloy's `Provider` instead of jsonrpsee's `WsClient`
- This automatically enables both http and ws transport instead of just ws RPCs like previously
- `RpcServer` is multichain and chain-specific RPCs at `/chainName` or `/:chainId`