### PR TITLE
feat: QoL config updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist
 
 # We keep the symbolic link
 !dist/browser-ui
+
+# ignore the packaged zip file
+/nexum_companion*.zip

--- a/crates/nexum/tui/src/config.rs
+++ b/crates/nexum/tui/src/config.rs
@@ -27,13 +27,32 @@ pub struct Config {
     #[serde(default)]
     pub labels: BTreeMap<NamedChain, HashMap<Address, String>>,
     #[serde(default)]
+    pub signer: SignerConfig,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
+pub struct SignerConfig {
+    #[serde(default)]
     pub keystores: Vec<KeystoreDir>,
+    #[serde(default)]
+    pub ledger: LedgerConfig,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct KeystoreDir {
     dir: String,
     ignore: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct LedgerConfig {
+    pub n: usize,
+}
+
+impl Default for LedgerConfig {
+    fn default() -> Self {
+        Self { n: 10 }
+    }
 }
 
 impl Config {
@@ -62,6 +81,7 @@ impl Config {
 
     pub fn keystores(&self) -> eyre::Result<Vec<NexumAccount>> {
         Ok(self
+            .signer
             .keystores
             .iter()
             .map(|k| {

--- a/crates/nexum/tui/src/config_tab.rs
+++ b/crates/nexum/tui/src/config_tab.rs
@@ -13,7 +13,7 @@ use ratatui::{
 use crate::{config::Config, HandleEvent};
 
 pub struct ConfigTab {
-    config: Config,
+    pub config: Config,
     config_list_state: Mutex<ListState>,
     origin_connections_collapsed: RwLock<bool>,
     labels_collapsed: RwLock<bool>,

--- a/crates/nexum/tui/src/main.rs
+++ b/crates/nexum/tui/src/main.rs
@@ -236,7 +236,7 @@ impl App {
         // load ledger accounts in background because its too slow
         let wallet_pane_clone = self.wallet_pane.clone();
         tokio::spawn(async move {
-            load_ledger_accounts(10)
+            load_ledger_accounts(self.config_tab.config.signer.ledger.n)
                 .await
                 .map(|accounts| wallet_pane_clone.add_accounts(accounts))
                 .ok();

--- a/crates/nexum/tui/src/main.rs
+++ b/crates/nexum/tui/src/main.rs
@@ -32,7 +32,7 @@ use ratatui::{
     },
     DefaultTerminal, Frame,
 };
-use signers::{load_foundry_keystores, load_ledger_accounts, NexumAccount};
+use signers::{load_ledger_accounts, NexumAccount};
 use tokio::sync::{mpsc, oneshot};
 use tracing_subscriber::EnvFilter;
 
@@ -209,7 +209,12 @@ impl App {
             active_tab: AppTab::default(),
             wallet_pane: Arc::new(WalletPane {
                 is_active: RwLock::new(true),
-                accounts: RwLock::new(load_foundry_keystores().unwrap_or_default()),
+                accounts: RwLock::new(
+                    config
+                        .keystores()
+                        .inspect_err(|err| tracing::error!(?err, "error loading foundry keystores"))
+                        .unwrap_or_default(),
+                ),
                 list_state: RwLock::new(list_state),
                 active_wallet_idx: RwLock::new(None),
                 prompt_sender: sender.clone(),

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ run-ext:
 
 alias pe := pack-ext
 pack-ext:
-	web-ext build -s crates/nexum/extension/dist -a .
+	web-ext build -s crates/nexum/extension/dist -a . --overwrite-dest
 
 clippy:
 	cargo clippy --all-targets --all-features --workspace -- -Dwarnings

--- a/justfile
+++ b/justfile
@@ -14,6 +14,10 @@ alias re := run-ext
 run-ext:
 	web-ext run -s crates/nexum/extension/dist
 
+alias pe := pack-ext
+pack-ext:
+	web-ext build -s crates/nexum/extension/dist -a .
+
 clippy:
 	cargo clippy --all-targets --all-features --workspace -- -Dwarnings
 


### PR DESCRIPTION
- Allow users to specify directories where it should look for keystores and also allow them to ignore specific files.
- Allow users to specify how many ledger accounts they want to load. Defaults to 10.
- Add just recipe for packaging extension